### PR TITLE
Format and Dismiss Animation Controllers when dismissing feature discovery

### DIFF
--- a/lib/src/feature_discovery.dart
+++ b/lib/src/feature_discovery.dart
@@ -7,33 +7,28 @@ class FeatureDiscovery extends StatefulWidget {
   const FeatureDiscovery({Key key, this.child}) : super(key: key);
 
   static String activeStep(BuildContext context) {
-    return (context.inheritFromWidgetOfExactType(_InheritedFeatureDiscovery)
-            as _InheritedFeatureDiscovery)
-        .activeStepId;
+    return _InheritedFeatureDiscovery.of(context).activeStepId;
   }
 
   /// Steps are the featureIds of the overlays.
   /// Though they can be placed in any [Iterable], it is recommended to pass them as a [Set], as they have to be unique
   static void discoverFeatures(BuildContext context, Iterable<String> steps) {
-    assert(steps.toSet().length == steps.length, "Feature ids must be unique"); 
+    assert(steps.toSet().length == steps.length, "Feature ids must be unique");
     _FeatureDiscoveryState state =
-        context.ancestorStateOfType(TypeMatcher<_FeatureDiscoveryState>())
-            as _FeatureDiscoveryState;
+        context.ancestorStateOfType(TypeMatcher<_FeatureDiscoveryState>()) as _FeatureDiscoveryState;
 
     state.discoverFeatures(steps.toList());
   }
 
   static void markStepComplete(BuildContext context, String stepId) {
     _FeatureDiscoveryState state =
-        context.ancestorStateOfType(TypeMatcher<_FeatureDiscoveryState>())
-            as _FeatureDiscoveryState;
+        context.ancestorStateOfType(TypeMatcher<_FeatureDiscoveryState>()) as _FeatureDiscoveryState;
     state.markStepComplete(stepId);
   }
 
   static dismiss(BuildContext context) {
     _FeatureDiscoveryState state =
-        context.ancestorStateOfType(TypeMatcher<_FeatureDiscoveryState>())
-            as _FeatureDiscoveryState;
+        context.ancestorStateOfType(TypeMatcher<_FeatureDiscoveryState>()) as _FeatureDiscoveryState;
 
     state.dismiss();
   }
@@ -88,16 +83,20 @@ class DescribedFeatureOverlay extends StatefulWidget {
   final IconData icon;
   @Deprecated("Replaced by backgroundColor")
   final Color color;
+
   /// If null, default to [ThemeData.primaryColor]
   final Color backgroundColor;
+
   /// If null, default to current [IconTheme]
   final Color iconColor;
   final Color targetColor;
   final Color textColor;
   final String title;
   final String description;
+
   /// Called when the target is pressed.
   final Function(VoidCallback onActionCompleted) doAction;
+
   /// Called just before the FeatureOverlay is displayed.
   /// The function parameter is actually the callback that triggers the display of the overlay.
   /// If not null, the callback MUST be called in order for the overlay to be displayed.
@@ -105,44 +104,44 @@ class DescribedFeatureOverlay extends StatefulWidget {
   final Widget child;
   final ContentOrientation contentLocation;
   final bool enablePulsingAnimation;
+
   /// Function to execute when the overlay is dismissed (when the user taps outside of it).
   /// If not null, the callback MUST be called in order for the overlay to be dismissed.
   final Function(VoidCallback onActionCompleted) onDismissAction;
 
-  const DescribedFeatureOverlay({
-    Key key,
-    @required this.featureId,
-    @required this.icon,
-    this.color,
-    this.backgroundColor,
-    this.iconColor,
-    this.targetColor = Colors.white,
-    this.textColor = Colors.white,
-    this.title,
-    this.description,
-    @required this.child,
-    this.doAction,
-    this.prepareAction,
-    this.contentLocation = ContentOrientation.trivial,
-    this.enablePulsingAnimation = true,
-    this.onDismissAction
-  }) : 
-    assert(featureId != null),
-    assert(icon != null),
-    assert(child != null),
-    assert(contentLocation != null),
-    assert(enablePulsingAnimation != null),
-    assert(targetColor != null),
-    assert(textColor != null),
-    assert(color == null || backgroundColor == null), // both are the same
-    super(key: key);
+  const DescribedFeatureOverlay(
+      {Key key,
+      @required this.featureId,
+      @required this.icon,
+      this.color,
+      this.backgroundColor,
+      this.iconColor,
+      this.targetColor = Colors.white,
+      this.textColor = Colors.white,
+      this.title,
+      this.description,
+      @required this.child,
+      this.doAction,
+      this.prepareAction,
+      this.contentLocation = ContentOrientation.trivial,
+      this.enablePulsingAnimation = true,
+      this.onDismissAction})
+      : assert(featureId != null),
+        assert(icon != null),
+        assert(child != null),
+        assert(contentLocation != null),
+        assert(enablePulsingAnimation != null),
+        assert(targetColor != null),
+        assert(textColor != null),
+        assert(color == null || backgroundColor == null),
+        // both are the same
+        super(key: key);
 
   @override
   _DescribedFeatureOverlayState createState() => _DescribedFeatureOverlayState();
 }
 
-class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
-    with TickerProviderStateMixin {
+class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay> with TickerProviderStateMixin {
   Size screenSize;
   double statusBarHeight;
   bool showOverlay = false;
@@ -170,33 +169,28 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   }
 
   void initAnimationControllers() {
-    openController =
-        AnimationController(vsync: this, duration: Duration(milliseconds: 250))
-          ..addListener(() => setState(() => transitionPercent = openController.value))
-          ..addStatusListener(
-            (AnimationStatus status) {
-              if (status == AnimationStatus.forward) setState(() => state = _OverlayState.opening);
-              else if (status == AnimationStatus.completed) pulseController?.forward(from: 0.0);
-            },
-          );
+    openController = AnimationController(vsync: this, duration: Duration(milliseconds: 250))
+      ..addListener(() => setState(() => transitionPercent = openController.value))
+      ..addStatusListener(
+        (AnimationStatus status) {
+          if (status == AnimationStatus.forward)
+            setState(() => state = _OverlayState.opening);
+          else if (status == AnimationStatus.completed) pulseController?.forward(from: 0.0);
+        },
+      );
 
     if (widget.enablePulsingAnimation) {
-      pulseController =
-          AnimationController(vsync: this, duration: Duration(milliseconds: 1000))
-            ..addListener(() => setState(() => transitionPercent = pulseController.value))
-            ..addStatusListener(
-              (AnimationStatus status) {
-                if (status == AnimationStatus.forward)
-                  setState(() => state = _OverlayState.pulsing);
-                else if (status == AnimationStatus.completed)
-                  pulseController.forward(from: 0.0);
-              },
-            );
+      pulseController = AnimationController(vsync: this, duration: Duration(milliseconds: 1000))
+        ..addListener(() => setState(() => transitionPercent = pulseController.value))
+        ..addStatusListener(
+          (AnimationStatus status) {
+            if (status == AnimationStatus.forward)
+              setState(() => state = _OverlayState.pulsing);
+            else if (status == AnimationStatus.completed) pulseController.forward(from: 0.0);
+          },
+        );
     }
-    activationController = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: 250)
-    )
+    activationController = AnimationController(vsync: this, duration: Duration(milliseconds: 250))
       ..addListener(() => setState(() => transitionPercent = activationController.value))
       ..addStatusListener(
         (AnimationStatus status) {
@@ -205,28 +199,33 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
               setState(() => state = _OverlayState.activating);
               break;
             case AnimationStatus.completed:
-              void Function() callback = 
-                () => FeatureDiscovery.markStepComplete(context, widget.featureId);
-              widget.doAction == null ? callback() : widget.doAction(callback);
+              void Function() callback = () => FeatureDiscovery.markStepComplete(context, widget.featureId);
+              if (widget.doAction == null)
+                callback();
+              else
+                widget.doAction(callback);
               break;
-            default: break;
+            default:
+              break;
           }
         },
       );
 
-    dismissController =
-        AnimationController(vsync: this, duration: Duration(milliseconds: 250))
-          ..addListener(() => setState(() => transitionPercent = dismissController.value))
-          ..addStatusListener(
-            (AnimationStatus status) {
-              if (status == AnimationStatus.forward)
-                setState(() => state = _OverlayState.dismissing);
-              else if (status == AnimationStatus.completed) {
-                void Function() callback = () => FeatureDiscovery.dismiss(context);
-                widget.onDismissAction == null ? callback() : widget.onDismissAction(callback);
-              }
-            },
-          );
+    dismissController = AnimationController(vsync: this, duration: Duration(milliseconds: 250))
+      ..addListener(() => setState(() => transitionPercent = dismissController.value))
+      ..addStatusListener(
+        (AnimationStatus status) {
+          if (status == AnimationStatus.forward)
+            setState(() => state = _OverlayState.dismissing);
+          else if (status == AnimationStatus.completed) {
+            void Function() callback = () => FeatureDiscovery.dismiss(context);
+            if (widget.onDismissAction == null)
+              callback();
+            else
+              widget.onDismissAction(callback);
+          }
+        },
+      );
   }
 
   @override
@@ -240,13 +239,21 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   void showOverlayIfActiveStep() {
     String activeStep = FeatureDiscovery.activeStep(context);
 
+    if (activeStep == null) {
+      // This condition is met when the feature discovery was dismissed
+      // and in that case the AnimationController's need to be dismissed as well.
+      openController.stop();
+      pulseController?.stop();
+    }
+
     void Function() callback = () {
       setState(() => showOverlay = activeStep == widget.featureId);
       if (activeStep == widget.featureId) openController.forward(from: 0.0);
     };
     if (widget.prepareAction != null && activeStep == widget.featureId)
       widget.prepareAction(callback);
-    else callback();
+    else
+      callback();
   }
 
   void activate() {
@@ -340,14 +347,13 @@ class _Background extends StatelessWidget {
     @required this.state,
     @required this.transitionPercent,
     @required this.orientation,
-  }) : 
-    assert(anchor != null),
-    assert(color != null),
-    assert(screenSize != null),
-    assert(state != null),
-    assert(transitionPercent != null),
-    assert(orientation != null),
-    super(key: key);
+  })  : assert(anchor != null),
+        assert(color != null),
+        assert(screenSize != null),
+        assert(state != null),
+        assert(transitionPercent != null),
+        assert(orientation != null),
+        super(key: key);
 
   bool isCloseToTopOrBottom(Offset position) {
     return position.dy <= 88.0 || (screenSize.height - position.dy) <= 88.0;
@@ -363,12 +369,10 @@ class _Background extends StatelessWidget {
 
   double radius() {
     final isBackgroundCentered = isCloseToTopOrBottom(anchor);
-    final backgroundRadius = Math.min(screenSize.width, screenSize.height) *
-        (isBackgroundCentered ? 1.0 : 0.7);
+    final backgroundRadius = Math.min(screenSize.width, screenSize.height) * (isBackgroundCentered ? 1.0 : 0.7);
     switch (state) {
       case _OverlayState.opening:
-        final adjustedPercent = const Interval(0.0, 0.8, curve: Curves.easeOut)
-            .transform(transitionPercent);
+        final adjustedPercent = const Interval(0.0, 0.8, curve: Curves.easeOut).transform(transitionPercent);
         return backgroundRadius * adjustedPercent;
       case _OverlayState.activating:
         return backgroundRadius + transitionPercent * 40.0;
@@ -391,37 +395,27 @@ class _Background extends StatelessWidget {
       var endingBackgroundPosition;
       switch (orientation) {
         case ContentOrientation.trivial:
-          endingBackgroundPosition = Offset(
-              width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0),
-              anchor.dy +
-                  (isOnTopHalfOfScreen(anchor)
-                      ? -(width / 2.0) + 40.0
-                      : (width / 2.0) - 40.0));
+          endingBackgroundPosition = Offset(width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0),
+              anchor.dy + (isOnTopHalfOfScreen(anchor) ? -(width / 2.0) + 40.0 : (width / 2.0) - 40.0));
           break;
         case ContentOrientation.above:
-          endingBackgroundPosition = Offset(
-              width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0),
-              anchor.dy - (width / 2.0) + 40.0);
+          endingBackgroundPosition =
+              Offset(width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0), anchor.dy - (width / 2.0) + 40.0);
           break;
         case ContentOrientation.below:
-          endingBackgroundPosition = Offset(
-              width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0),
-              anchor.dy + (width / 2.0) - 40.0);
+          endingBackgroundPosition =
+              Offset(width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0), anchor.dy + (width / 2.0) - 40.0);
           break;
       }
 
       switch (state) {
         case _OverlayState.opening:
-          final adjustedPercent =
-              const Interval(0.0, 0.8, curve: Curves.easeOut)
-                  .transform(transitionPercent);
-          return Offset.lerp(startingBackgroundPosition,
-              endingBackgroundPosition, adjustedPercent);
+          final adjustedPercent = const Interval(0.0, 0.8, curve: Curves.easeOut).transform(transitionPercent);
+          return Offset.lerp(startingBackgroundPosition, endingBackgroundPosition, adjustedPercent);
         case _OverlayState.activating:
           return endingBackgroundPosition;
         case _OverlayState.dismissing:
-          return Offset.lerp(endingBackgroundPosition,
-              startingBackgroundPosition, transitionPercent);
+          return Offset.lerp(endingBackgroundPosition, startingBackgroundPosition, transitionPercent);
         default:
           return endingBackgroundPosition;
       }
@@ -431,18 +425,15 @@ class _Background extends StatelessWidget {
   double backgroundOpacity() {
     switch (state) {
       case _OverlayState.opening:
-        final adjustedPercent = const Interval(0.0, 0.3, curve: Curves.easeOut)
-            .transform(transitionPercent);
+        final adjustedPercent = const Interval(0.0, 0.3, curve: Curves.easeOut).transform(transitionPercent);
         return 0.96 * adjustedPercent;
 
       case _OverlayState.activating:
-        final adjustedPercent = const Interval(0.1, 0.6, curve: Curves.easeOut)
-            .transform(transitionPercent);
+        final adjustedPercent = const Interval(0.1, 0.6, curve: Curves.easeOut).transform(transitionPercent);
 
         return 0.96 * (1 - adjustedPercent);
       case _OverlayState.dismissing:
-        final adjustedPercent = const Interval(0.2, 1.0, curve: Curves.easeOut)
-            .transform(transitionPercent);
+        final adjustedPercent = const Interval(0.2, 1.0, curve: Curves.easeOut).transform(transitionPercent);
         return 0.96 * (1 - adjustedPercent);
       default:
         return 0.96;
@@ -460,9 +451,7 @@ class _Background extends StatelessWidget {
       child: Container(
         width: 2 * radius(),
         height: 2 * radius(),
-        decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: color.withOpacity(backgroundOpacity())),
+        decoration: BoxDecoration(shape: BoxShape.circle, color: color.withOpacity(backgroundOpacity())),
       ),
     );
   }
@@ -474,18 +463,13 @@ class _Pulse extends StatelessWidget {
   final Offset anchor;
   final Color color;
 
-  const _Pulse({
-    Key key,
-    @required this.state,
-    @required this.transitionPercent,
-    @required this.anchor,
-    @required this.color
-  }) : 
-    assert(state != null),
-    assert(transitionPercent != null),
-    assert(anchor != null),
-    assert(color != null),
-    super(key: key);
+  const _Pulse(
+      {Key key, @required this.state, @required this.transitionPercent, @required this.anchor, @required this.color})
+      : assert(state != null),
+        assert(transitionPercent != null),
+        assert(anchor != null),
+        assert(color != null),
+        super(key: key);
 
   double radius() {
     switch (state) {
@@ -508,8 +492,7 @@ class _Pulse extends StatelessWidget {
   double opacity() {
     switch (state) {
       case _OverlayState.pulsing:
-        final percentOpaque =
-            1.0 - ((transitionPercent.clamp(0.3, 0.8) - 0.3) / 0.5);
+        final percentOpaque = 1.0 - ((transitionPercent.clamp(0.3, 0.8) - 0.3) / 0.5);
         return (percentOpaque * 0.75).clamp(0.0, 1.0);
       case _OverlayState.activating:
       case _OverlayState.dismissing:
@@ -522,18 +505,18 @@ class _Pulse extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return state == _OverlayState.closed
-      ? Container(height: 0, width: 0)
-      : CenterAbout(
-        position: anchor,
-        child: Container(
-          width: radius() * 2,
-          height: radius() * 2,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: color.withOpacity(opacity()),
-          ),
-        ),
-      );
+        ? Container(height: 0, width: 0)
+        : CenterAbout(
+            position: anchor,
+            child: Container(
+              width: radius() * 2,
+              height: radius() * 2,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: color.withOpacity(opacity()),
+              ),
+            ),
+          );
   }
 }
 
@@ -558,24 +541,20 @@ class _TouchTarget extends StatelessWidget {
     @required this.backgroundColor,
     @required this.state,
     @required this.transitionPercent,
-  }) : 
-    assert(anchor != null),
-    assert(icon != null),
-    assert(state != null),
-    assert(transitionPercent != null),
-    assert(backgroundColor != null),
-    super(key: key);
+  })  : assert(anchor != null),
+        assert(icon != null),
+        assert(state != null),
+        assert(transitionPercent != null),
+        assert(backgroundColor != null),
+        super(key: key);
 
   double opacity() {
     switch (state) {
       case _OverlayState.opening:
-        return const Interval(0.0, 0.3, curve: Curves.easeOut)
-            .transform(transitionPercent);
+        return const Interval(0.0, 0.3, curve: Curves.easeOut).transform(transitionPercent);
       case _OverlayState.activating:
       case _OverlayState.dismissing:
-        return 1.0 -
-            const Interval(0.7, 1.0, curve: Curves.easeOut)
-                .transform(transitionPercent);
+        return 1.0 - const Interval(0.7, 1.0, curve: Curves.easeOut).transform(transitionPercent);
       default:
         return 1.0;
     }
@@ -593,7 +572,8 @@ class _TouchTarget extends StatelessWidget {
           expandedPercent = transitionPercent / 0.3;
         else if (transitionPercent < 0.6)
           expandedPercent = 1.0 - ((transitionPercent - 0.3) / 0.3);
-        else expandedPercent = 0.0;
+        else
+          expandedPercent = 0.0;
         return 44.0 + (20.0 * expandedPercent);
       case _OverlayState.activating:
       case _OverlayState.dismissing:
@@ -633,39 +613,41 @@ class _Content extends StatelessWidget {
   final Offset anchor;
   final Size screenSize;
   final double touchTargetRadius;
+
   // this parameter is not used
   // final double touchTargetToContentPadding;
   /// Can be null
   final String title;
+
   /// Can be null
   final String description;
+
   // not used
   // final double statusBarHeight;
   final ContentOrientation orientation;
   final Color textColor;
 
-  const _Content(
-      {Key key,
-      @required this.anchor,
-      @required this.screenSize,
-      @required this.touchTargetRadius,
-      //this.touchTargetToContentPadding,
-      @required this.title,
-      @required this.description,
-      @required this.state,
-      @required this.transitionPercent,
-      //this.statusBarHeight,
-      @required this.orientation,
-      @required this.textColor,
-    }) : 
-      assert(anchor != null),
-      assert(screenSize != null),
-      assert(touchTargetRadius != null),
-      assert(state != null),
-      assert(transitionPercent != null),
-      assert(orientation != null),
-      assert(textColor != null),
-      super(key: key);
+  const _Content({
+    Key key,
+    @required this.anchor,
+    @required this.screenSize,
+    @required this.touchTargetRadius,
+    //this.touchTargetToContentPadding,
+    @required this.title,
+    @required this.description,
+    @required this.state,
+    @required this.transitionPercent,
+    //this.statusBarHeight,
+    @required this.orientation,
+    @required this.textColor,
+  })  : assert(anchor != null),
+        assert(screenSize != null),
+        assert(touchTargetRadius != null),
+        assert(state != null),
+        assert(transitionPercent != null),
+        assert(orientation != null),
+        assert(textColor != null),
+        super(key: key);
 
   bool isCloseToTopOrBottom(Offset position) {
     return position.dy <= 88.0 || (screenSize.height - position.dy) <= 88.0;
@@ -680,14 +662,14 @@ class _Content extends StatelessWidget {
   }
 
   DescribedFeatureContentOrientation getContentOrientation(Offset position) {
-    if (isCloseToTopOrBottom(position)) return 
-      isOnTopHalfOfScreen(position)
-        ? DescribedFeatureContentOrientation.below
-        : DescribedFeatureContentOrientation.above;
-    else return 
-      isOnTopHalfOfScreen(position)
-        ? DescribedFeatureContentOrientation.above
-        : DescribedFeatureContentOrientation.below;
+    if (isCloseToTopOrBottom(position))
+      return isOnTopHalfOfScreen(position)
+          ? DescribedFeatureContentOrientation.below
+          : DescribedFeatureContentOrientation.above;
+    else
+      return isOnTopHalfOfScreen(position)
+          ? DescribedFeatureContentOrientation.above
+          : DescribedFeatureContentOrientation.below;
   }
 
   double opacity() {
@@ -695,13 +677,11 @@ class _Content extends StatelessWidget {
       case _OverlayState.closed:
         return 0.0;
       case _OverlayState.opening:
-        final adjustedPercent = const Interval(0.6, 1.0, curve: Curves.easeOut)
-            .transform(transitionPercent);
+        final adjustedPercent = const Interval(0.6, 1.0, curve: Curves.easeOut).transform(transitionPercent);
         return adjustedPercent;
       case _OverlayState.activating:
       case _OverlayState.dismissing:
-        final adjustedPercent = const Interval(0.0, 0.4, curve: Curves.easeOut)
-            .transform(transitionPercent);
+        final adjustedPercent = const Interval(0.0, 0.4, curve: Curves.easeOut).transform(transitionPercent);
         return 1.0 - adjustedPercent;
       default:
         return 1.0;
@@ -712,28 +692,21 @@ class _Content extends StatelessWidget {
     final width = Math.min(screenSize.width, screenSize.height);
     final isBackgroundCentered = isCloseToTopOrBottom(anchor);
 
-    if (isBackgroundCentered) return anchor;
+    if (isBackgroundCentered)
+      return anchor;
     else {
       final startingBackgroundPosition = anchor;
-      final endingBackgroundPosition = Offset(
-          width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0),
-          anchor.dy +
-              (isOnTopHalfOfScreen(anchor)
-                  ? -(width / 2) + 40.0
-                  : (width / 20.0) - 40.0));
+      final endingBackgroundPosition = Offset(width / 2.0 + (isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0),
+          anchor.dy + (isOnTopHalfOfScreen(anchor) ? -(width / 2) + 40.0 : (width / 20.0) - 40.0));
 
       switch (state) {
         case _OverlayState.opening:
-          final adjustedPercent =
-              const Interval(0.0, 0.8, curve: Curves.easeOut)
-                  .transform(transitionPercent);
-          return Offset.lerp(startingBackgroundPosition,
-              endingBackgroundPosition, adjustedPercent);
+          final adjustedPercent = const Interval(0.0, 0.8, curve: Curves.easeOut).transform(transitionPercent);
+          return Offset.lerp(startingBackgroundPosition, endingBackgroundPosition, adjustedPercent);
         case _OverlayState.activating:
           return endingBackgroundPosition;
         case _OverlayState.dismissing:
-          return Offset.lerp(endingBackgroundPosition,
-              startingBackgroundPosition, transitionPercent);
+          return Offset.lerp(endingBackgroundPosition, startingBackgroundPosition, transitionPercent);
         default:
           return endingBackgroundPosition;
       }
@@ -747,10 +720,7 @@ class _Content extends StatelessWidget {
 
     switch (orientation) {
       case ContentOrientation.trivial:
-        contentOffsetMultiplier =
-            contentOrientation == DescribedFeatureContentOrientation.below
-                ? 1.0
-                : -1.0;
+        contentOffsetMultiplier = contentOrientation == DescribedFeatureContentOrientation.below ? 1.0 : -1.0;
         break;
       case ContentOrientation.above:
         contentOffsetMultiplier = -1.0;
@@ -762,8 +732,7 @@ class _Content extends StatelessWidget {
 
     final width = Math.min(screenSize.width, screenSize.height);
 
-    final contentY =
-        anchor.dy + contentOffsetMultiplier * (touchTargetRadius + 20);
+    final contentY = anchor.dy + contentOffsetMultiplier * (touchTargetRadius + 20);
 
     final contentFractionalOffset = contentOffsetMultiplier.clamp(-1.0, 0.0);
 
@@ -786,20 +755,15 @@ class _Content extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     title == null
-                      ? const SizedBox(height: 0)
-                      : Text(
-                        title,
-                        style: Theme.of(context).textTheme.title
-                          .copyWith(color: textColor)
-                      ),
+                        ? const SizedBox(height: 0)
+                        : Text(title, style: Theme.of(context).textTheme.title.copyWith(color: textColor)),
                     const SizedBox(height: 8.0),
                     description == null
-                      ? const SizedBox(height: 0)
-                      : Text(
-                        description,
-                        style: Theme.of(context).textTheme.body1
-                          .copyWith(color: textColor.withOpacity(0.9)),
-                      ),
+                        ? const SizedBox(height: 0)
+                        : Text(
+                            description,
+                            style: Theme.of(context).textTheme.body1.copyWith(color: textColor.withOpacity(0.9)),
+                          ),
                   ],
                 ),
               ),
@@ -821,13 +785,11 @@ class _InheritedFeatureDiscovery extends InheritedWidget {
   })  : assert(child != null),
         super(key: key, child: child);
 
-  static _InheritedFeatureDiscovery of(BuildContext context)
-    => context.inheritFromWidgetOfExactType(_InheritedFeatureDiscovery)
-      as _InheritedFeatureDiscovery;
+  static _InheritedFeatureDiscovery of(BuildContext context) =>
+      context.inheritFromWidgetOfExactType(_InheritedFeatureDiscovery) as _InheritedFeatureDiscovery;
 
   @override
-  bool updateShouldNotify(_InheritedFeatureDiscovery old)
-    => old.activeStepId != activeStepId;
+  bool updateShouldNotify(_InheritedFeatureDiscovery old) => old.activeStepId != activeStepId;
 }
 
 enum DescribedFeatureContentOrientation {


### PR DESCRIPTION
When Feature Discovery was dismissed previously, the animation controllers just continued animating. Now, I fixed that and quickly ran format to make the code readable again.