### PR TITLE
Shortened pubspec description

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: feature_discovery
 description: >-
   A Flutter package that implements Material Design Feature discovery
   to show a description of specific features to new users.
-  See https://material.io/archive/guidelines/growth-communications/feature-discovery.html
+  See https://tinyurl.com/FeatureDiscovery
 version: 0.5.1
 authors: 
   - ayalma <alimohammadi7117@gmail.com>


### PR DESCRIPTION
A description whose length is more than 180 characters reduces maintenance score of the package