### PR TITLE
Fix provider lookup

### DIFF
--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -562,10 +562,9 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     return Stack(
       children: <Widget>[
         GestureDetector(
-          onTap: () => FeatureDiscovery.dismiss(context),
+          onTap: bloc.dismiss,
           // According to the spec, the user should be able to dismiss by swiping.
-          onPanUpdate: (DragUpdateDetails _) =>
-              FeatureDiscovery.dismiss(context),
+          onPanUpdate: (DragUpdateDetails _) => bloc.dismiss(),
           child: Container(
             width: double.infinity,
             height: double.infinity,


### PR DESCRIPTION
It is possible that the `context` is null when the `GestureDetector` callbacks are called. This will result in the following error:

```
Non-fatal Exception: java.lang.Exception: NoSuchMethodError: The method 'ancestorInheritedElementForWidgetOfExactType' was called on null.
Receiver: null
Tried calling: ancestorInheritedElementForWidgetOfExactType()
       at Provider.of(Provider.java:256)
       at Bloc.of(Bloc.java:23)
       at FeatureDiscovery.dismiss(FeatureDiscovery.java:38)
       at _DescribedFeatureOverlayState._buildOverlay.<fn>(_buildOverlay.java:568)
       at DragGestureRecognizer._checkUpdate.<fn>(_checkUpdate.java:403)
```

This pull request fixes the error. Changelog entry is not required as the changes are still not merged in https://github.com/ayalma/feature_discovery.