### PR TITLE
Fix issues with overlay dismissing & update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Non breaking:
   * Incorrect documentation of some static methods in `FeatureDiscovery` has been edited.
   * Error messages have been improved : the error thrown when the widget tree isn't wrapped in a `FeatureDiscovery` widget is clearer.
+  * Incorrect behavior when `onDismiss` returned `Future<false>` has been fixed:
+    * overlays will always be dismissed when calling `FeatureDiscovery.dismissAll`;
+    * a step can be completed after the user tries to dismiss it.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,16 @@
-# Changelog
-
 ## 0.7.0
 
-* **Breaking changes:**
-  * Deprecated static methods of `FeatureDiscovery` class have been removed.
-  * Deprecated paramaters in the constructor of `EnsureVisible` have been removed.
-* **Deprecations:**
-  * `activeFeatureId` has been deprecated and replaced by `currentFeatureIdOf`, to emphasize that this is a getter.
-  * `dismiss` has been deprecated and replaced by `dismissAll` to be clear on the fact that no next step will be shown.
-* Non breaking:
-  * Incorrect documentation of some static methods in `FeatureDiscovery` has been edited.
-  * Error messages have been improved : the error thrown when the widget tree isn't wrapped in a `FeatureDiscovery` widget is clearer.
-  * Incorrect behavior when `onDismiss` returned `Future<false>` has been fixed:
-    * overlays will always be dismissed when calling `FeatureDiscovery.dismissAll`;
-    * a step can be completed after the user tries to dismiss it.
+* **Breaking change:** removed deprecated static methods in `FeatureDiscovery`.
+* **Breaking change:** removed deprecated parameters in the `EnsureVisible` constructor.
+* **Breaking change:** overlays will always be dismissed when calling `FeatureDiscovery.dismissAll`.
+* *Deprecated* `activeFeatureId`; replaced by `currentFeatureIdOf` to emphasize that this is a getter.
+* *Deprecated* `FeatureDiscovery.dismiss`; replaced by `dismissAll` to indicate that no next step
+  will be shown.
+* Added `assert` to require at least one step to be passed to `FeatureDiscovery.discoverFeatures`.
+* Incorrect documentation of some static methods in `FeatureDiscovery` has been updated.
+* Error messages have been improved : the error thrown when the widget tree isn't wrapped in
+  a `FeatureDiscovery` widget is clearer.
+* Incorrect behavior when `onDismiss` returned `Future<false>` has been fixed.
 
 ## 0.6.1
 

--- a/lib/src/foundation/bloc.dart
+++ b/lib/src/foundation/bloc.dart
@@ -81,7 +81,7 @@ class Bloc {
     _eventsController.close();
   }
 
-  void discoverFeatures({Iterable<String> steps}) {
+  void discoverFeatures({@required Iterable<String> steps}) {
     assert(steps != null);
     _steps = steps;
     _activeStepIndex = 0;

--- a/lib/src/foundation/bloc.dart
+++ b/lib/src/foundation/bloc.dart
@@ -81,8 +81,8 @@ class Bloc {
     _eventsController.close();
   }
 
-  void discoverFeatures({@required Iterable<String> steps}) {
-    assert(steps != null);
+  void discoverFeatures(Iterable<String> steps) {
+    assert(steps != null && steps.isNotEmpty, 'You need to pass at least one step to [FeatureDiscovery.discoverFeatures].');
     _steps = steps;
     _activeStepIndex = 0;
     _activeOverlays = 0;

--- a/lib/src/foundation/bloc.dart
+++ b/lib/src/foundation/bloc.dart
@@ -82,7 +82,8 @@ class Bloc {
   }
 
   void discoverFeatures(Iterable<String> steps) {
-    assert(steps != null && steps.isNotEmpty, 'You need to pass at least one step to [FeatureDiscovery.discoverFeatures].');
+    assert(steps != null && steps.isNotEmpty,
+        'You need to pass at least one step to [FeatureDiscovery.discoverFeatures].');
     _steps = steps;
     _activeStepIndex = 0;
     _activeOverlays = 0;

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -42,7 +42,7 @@ class FeatureDiscovery extends StatelessWidget {
   /// call [completeCurrentStep] instead.
   static void dismissAll(BuildContext context) => _blocOf(context).dismiss();
 
-  @Deprecated("Use [dismissAll] instead.")
+  @Deprecated('Use [dismissAll] instead.')
   static void dismiss(BuildContext context) => dismissAll(context);
 
   /// This returns the feature id of the current feature discovery step, i.e.
@@ -55,7 +55,7 @@ class FeatureDiscovery extends StatelessWidget {
   static String currentFeatureIdOf(BuildContext context) =>
       _blocOf(context).activeFeatureId;
 
-  @Deprecated("Use [currentFeatureIdOf] instead.")
+  @Deprecated('Use [currentFeatureIdOf] instead.')
   static String activeFeatureId(BuildContext context) =>
       currentFeatureIdOf(context);
 

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -36,9 +36,10 @@ class FeatureDiscovery extends StatelessWidget {
   static void completeCurrentStep(BuildContext context) =>
       _blocOf(context).completeStep();
 
-  /// This will schedule dismissal of the current discovery step and with that
-  /// of the current feature discovery. The dismissal animation will play if successful.
-  /// If you want to complete the step and continue the feature discovery,
+  /// A method to dismiss all steps.
+  ///
+  /// The `onDimiss` parameter will be ignored for every active overlay.
+  /// If you want to complete the current step and continue the feature discovery,
   /// call [completeCurrentStep] instead.
   static void dismissAll(BuildContext context) => _blocOf(context).dismiss();
 

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -29,7 +29,7 @@ class FeatureDiscovery extends StatelessWidget {
   /// Though they can be placed in any [Iterable], it is recommended to pass them as a [Set]
   /// because this ensures that every step is only shown once.
   static void discoverFeatures(BuildContext context, Iterable<String> steps) =>
-      _blocOf(context).discoverFeatures(steps: steps.toList());
+      _blocOf(context).discoverFeatures(steps.toList());
 
   /// This will schedule completion of the current discovery step and continue
   /// onto the step after the completion animation of the current overlay if successful.

--- a/lib/src/rendering/custom_layout.dart
+++ b/lib/src/rendering/custom_layout.dart
@@ -85,12 +85,12 @@ class BackgroundContentLayoutDelegate extends MultiChildLayoutDelegate {
       final distanceToOuterPulse = anchorPoint.distanceTo(backgroundPoint) + 75;
 
       // Calculate distance to the furthest point of the content.
-      final Rect contentArea = Rect.fromLTWH(contentPoint.x, contentPoint.y,
+      final contentArea = Rect.fromLTWH(contentPoint.x, contentPoint.y,
           contentSize.width, contentSize.height);
       // This is equal to finding the max out of the distances to the corners of the Rect.
       // It is just the more Math-esque approach.
       // See the commented out code below for an intuitive approach.
-      final double contentDx = max((contentArea.left - backgroundPoint.x).abs(),
+      final contentDx = max((contentArea.left - backgroundPoint.x).abs(),
               (contentArea.right - backgroundPoint.x)),
           contentDy = max((contentArea.top - backgroundPoint.y).abs(),
               (contentArea.bottom - backgroundPoint.y).abs());

--- a/lib/src/widgets/content.dart
+++ b/lib/src/widgets/content.dart
@@ -43,15 +43,13 @@ class Content extends StatelessWidget {
       case FeatureOverlayState.closed:
         return 0;
       case FeatureOverlayState.opening:
-        final double adjustedPercent =
-            const Interval(0.6, 1, curve: Curves.easeOut)
-                .transform(transitionProgress);
+        final adjustedPercent = const Interval(0.6, 1, curve: Curves.easeOut)
+            .transform(transitionProgress);
         return adjustedPercent;
       case FeatureOverlayState.completing:
       case FeatureOverlayState.dismissing:
-        final double adjustedPercent =
-            const Interval(0, 0.4, curve: Curves.easeOut)
-                .transform(transitionProgress);
+        final adjustedPercent = const Interval(0, 0.4, curve: Curves.easeOut)
+            .transform(transitionProgress);
         return 1 - adjustedPercent;
       case FeatureOverlayState.opened:
         return 1;
@@ -79,7 +77,7 @@ class Content extends StatelessWidget {
                   DefaultTextStyle(
                     style: Theme.of(context)
                         .textTheme
-                        .title
+                        .headline6
                         .copyWith(color: textColor),
                     child: title,
                   ),
@@ -89,7 +87,7 @@ class Content extends StatelessWidget {
                   DefaultTextStyle(
                     style: Theme.of(context)
                         .textTheme
-                        .body1
+                        .body1 // TODO(creativecreatorormaybenot): Update to bodyText2 when Flutter stable deprecates body1.
                         .copyWith(color: textColor.withOpacity(0.9)),
                     child: description,
                   )

--- a/lib/src/widgets/content.dart
+++ b/lib/src/widgets/content.dart
@@ -77,7 +77,7 @@ class Content extends StatelessWidget {
                   DefaultTextStyle(
                     style: Theme.of(context)
                         .textTheme
-                        .headline6
+                        .title // TODO(creativecreatorormaybenot): Update to headline6 when Flutter stable deprecates title.
                         .copyWith(color: textColor),
                     child: title,
                   ),

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -359,15 +359,13 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     _close();
   }
 
-  /// If [force] is true, the [onDismiss] function will be awaited
-  /// but its returned value will be ignored.
   Future<void> _dismiss({bool force = false}) async {
     // The method might be triggered multiple times, especially when swiping.
     if (_awaitingClosure) return;
 
     _awaitingClosure = true;
 
-    if (widget.onDismiss != null) {
+    if (!force && widget.onDismiss != null) {
       bool shouldDismiss;
       try {
         shouldDismiss = await widget.onDismiss();
@@ -377,7 +375,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
 
       assert(shouldDismiss != null,
           'You need to return a [Future] that completes with true or false in [onDismiss].');
-      if (!shouldDismiss && !force) return;
+      if (!shouldDismiss) return;
     }
     _openController.stop();
     _pulseController.stop();

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -39,7 +39,8 @@ class DescribedFeatureOverlay extends StatefulWidget {
   /// It is intended for this to contain a [Text] widget, however, you can pass
   /// any [Widget].
   /// The overlay uses a [DefaultTextStyle] for the title, which is a combination
-  /// of [TextTheme.headline6] from [Theme] and the [textColor].
+  /// of [TextTheme.title] from [Theme] and the [textColor].
+  // TODO(creativecreatorormaybenot): Update TextTheme.title link to headline6 when Flutter stable deprecates body1.
   final Widget title;
 
   /// This is the second content widget, i.e. it is displayed below [description].

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -567,12 +567,22 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
           contentOffsetMultiplier * (44 + 20), // 44 is the tap target's radius.
     );
 
+    // Will try to dismiss this overlay,
+    // then will call the bloc's dismiss function
+    // only if this overlay has been successfully dismissed.
+    void tryDismissThisThenAll() async {
+      await _dismiss();
+      if (_state == FeatureOverlayState.closed) {
+        _bloc.dismiss();
+      }
+    }
+
     return Stack(
       children: <Widget>[
         GestureDetector(
-          onTap: _bloc.dismiss,
+          onTap: tryDismissThisThenAll,
           // According to the spec, the user should be able to dismiss by swiping.
-          onPanUpdate: (DragUpdateDetails _) => _bloc.dismiss(),
+          onPanUpdate: (DragUpdateDetails _) => tryDismissThisThenAll(),
           child: Container(
             width: double.infinity,
             height: double.infinity,

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -39,7 +39,7 @@ class DescribedFeatureOverlay extends StatefulWidget {
   /// It is intended for this to contain a [Text] widget, however, you can pass
   /// any [Widget].
   /// The overlay uses a [DefaultTextStyle] for the title, which is a combination
-  /// of [TextTheme.title] from [Theme] and the [textColor].
+  /// of [TextTheme.headline6] from [Theme] and the [textColor].
   final Widget title;
 
   /// This is the second content widget, i.e. it is displayed below [description].
@@ -48,6 +48,7 @@ class DescribedFeatureOverlay extends StatefulWidget {
   /// any [Widget].
   /// The overlay uses a [DefaultTextStyle] for the description, which is a combination
   /// of [TextTheme.body1] from [Theme] and the [textColor].
+  // TODO(creativecreatorormaybenot): Update TextTheme.body1 link to bodyText2 when Flutter stable deprecates body1.
   final Widget description;
 
   /// This is usually an [Icon].
@@ -194,7 +195,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     try {
       _bloc = Bloc.of(context);
 
-      final Stream<EventType> newEventsStream = _bloc.eventsOut;
+      final newEventsStream = _bloc.eventsOut;
       if (_eventsStream != newEventsStream) _setStream(newEventsStream);
 
       // If this widget was not in the tree when the feature discovery was started,
@@ -305,7 +306,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     _bloc.activeOverlays++;
 
     if (widget.onOpen != null) {
-      final bool shouldOpen = await widget.onOpen();
+      final shouldOpen = await widget.onOpen();
       assert(shouldOpen != null,
           'You need to return a [Future] that completes with true or false in [onOpen].');
       if (!shouldOpen) {
@@ -428,15 +429,15 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   /// The value returned from here will be adjusted in [BackgroundContentLayoutDelegate]
   /// in order to match the transition progress and overlay state.
   double _backgroundRadius(Offset anchor) {
-    final bool isBackgroundCentered = _isCloseToTopOrBottom(anchor);
-    final double backgroundRadius = min(_screenSize.width, _screenSize.height) *
+    final isBackgroundCentered = _isCloseToTopOrBottom(anchor);
+    final backgroundRadius = min(_screenSize.width, _screenSize.height) *
         (isBackgroundCentered ? 1.0 : 0.7);
     return backgroundRadius;
   }
 
   Offset _backgroundPosition(Offset anchor, ContentLocation contentLocation) {
-    final double width = min(_screenSize.width, _screenSize.height);
-    final bool isBackgroundCentered = _isCloseToTopOrBottom(anchor);
+    final width = min(_screenSize.width, _screenSize.height);
+    final isBackgroundCentered = _isCloseToTopOrBottom(anchor);
 
     if (isBackgroundCentered) {
       return anchor;
@@ -461,7 +462,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
 
       switch (_state) {
         case FeatureOverlayState.opening:
-          final double adjustedPercent =
+          final adjustedPercent =
               const Interval(0.0, 0.8, curve: Curves.easeOut)
                   .transform(_transitionProgress);
           return Offset.lerp(startingBackgroundPosition,
@@ -498,14 +499,14 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   }
 
   Offset _contentCenterPosition(Offset anchor) {
-    final double width = min(_screenSize.width, _screenSize.height);
-    final bool isBackgroundCentered = _isCloseToTopOrBottom(anchor);
+    final width = min(_screenSize.width, _screenSize.height);
+    final isBackgroundCentered = _isCloseToTopOrBottom(anchor);
 
     if (isBackgroundCentered) {
       return anchor;
     } else {
-      final Offset startingBackgroundPosition = anchor;
-      final Offset endingBackgroundPosition = Offset(
+      final startingBackgroundPosition = anchor;
+      final endingBackgroundPosition = Offset(
           width / 2.0 + (_isOnLeftHalfOfScreen(anchor) ? -20.0 : 20.0),
           anchor.dy +
               (_isOnTopHalfOfScreen(anchor)
@@ -514,7 +515,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
 
       switch (_state) {
         case FeatureOverlayState.opening:
-          final double adjustedPercent =
+          final adjustedPercent =
               const Interval(0.0, 0.8, curve: Curves.easeOut)
                   .transform(_transitionProgress);
           return Offset.lerp(startingBackgroundPosition,
@@ -544,22 +545,19 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   Widget _buildOverlay(Offset anchor) {
     // This will be assigned either above or below, i.e. trivial from
     // widget.contentLocation will be converted to above or below.
-    final ContentLocation contentLocation =
-        _nonTrivialContentOrientation(anchor);
+    final contentLocation = _nonTrivialContentOrientation(anchor);
     assert(contentLocation != ContentLocation.trivial);
 
-    final Offset backgroundCenter =
-        _backgroundPosition(anchor, contentLocation);
-    final double backgroundRadius = _backgroundRadius(anchor);
+    final backgroundCenter = _backgroundPosition(anchor, contentLocation);
+    final backgroundRadius = _backgroundRadius(anchor);
 
-    final double contentOffsetMultiplier =
-        _contentOffsetMultiplier(contentLocation);
-    final Offset contentCenterPosition = _contentCenterPosition(anchor);
+    final contentOffsetMultiplier = _contentOffsetMultiplier(contentLocation);
+    final contentCenterPosition = _contentCenterPosition(anchor);
 
-    final double contentWidth = min(_screenSize.width, _screenSize.height);
+    final contentWidth = min(_screenSize.width, _screenSize.height);
 
-    final double dx = contentCenterPosition.dx - contentWidth;
-    final Offset contentPosition = Offset(
+    final dx = contentCenterPosition.dx - contentWidth;
+    final contentPosition = Offset(
       (dx.isNegative) ? 0.0 : dx,
       anchor.dy +
           contentOffsetMultiplier * (44 + 20), // 44 is the tap target's radius.
@@ -671,21 +669,18 @@ class _Background extends StatelessWidget {
   double get opacity {
     switch (state) {
       case FeatureOverlayState.opening:
-        final double adjustedPercent =
-            const Interval(0.0, 0.3, curve: Curves.easeOut)
-                .transform(transitionProgress);
+        final adjustedPercent = const Interval(0.0, 0.3, curve: Curves.easeOut)
+            .transform(transitionProgress);
         return 0.96 * adjustedPercent;
 
       case FeatureOverlayState.completing:
-        final double adjustedPercent =
-            const Interval(0.1, 0.6, curve: Curves.easeOut)
-                .transform(transitionProgress);
+        final adjustedPercent = const Interval(0.1, 0.6, curve: Curves.easeOut)
+            .transform(transitionProgress);
 
         return 0.96 * (1 - adjustedPercent);
       case FeatureOverlayState.dismissing:
-        final double adjustedPercent =
-            const Interval(0.2, 1.0, curve: Curves.easeOut)
-                .transform(transitionProgress);
+        final adjustedPercent = const Interval(0.2, 1.0, curve: Curves.easeOut)
+            .transform(transitionProgress);
         return 0.96 * (1 - adjustedPercent);
       case FeatureOverlayState.opened:
         return 0.96;
@@ -753,7 +748,7 @@ class _Pulse extends StatelessWidget {
   double get opacity {
     switch (state) {
       case FeatureOverlayState.opened:
-        final double percentOpaque =
+        final percentOpaque =
             1 - ((transitionProgress.clamp(0.3, 0.8) - 0.3) / 0.5);
         return (percentOpaque * 0.75).clamp(0, 1);
       case FeatureOverlayState.completing:

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -251,7 +251,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
           // Only try opening when the active feature id matches the id of this widget.
           if (_bloc.activeFeatureId != widget.featureId) return;
           await _open();
-          return;
+          break;
         case EventType.complete:
         case EventType.dismiss:
           // This overlay was the active feature before this event if it is either opening or already opened.
@@ -261,11 +261,12 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
           if (event == EventType.complete) {
             await _complete();
           } else {
-            await _dismiss();
+            await _dismiss(force: true);
           }
-          return;
+          break;
+        default:
+          throw ArgumentError.value(event);
       }
-      throw ArgumentError.value(event);
     });
   }
 
@@ -358,7 +359,9 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     _close();
   }
 
-  Future<void> _dismiss() async {
+  /// If [force] is true, the [onDismiss] function will be awaited
+  /// but its returned value will be ignored.
+  Future<void> _dismiss({bool force = false}) async {
     // The method might be triggered multiple times, especially when swiping.
     if (_awaitingClosure) return;
 
@@ -374,7 +377,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
 
       assert(shouldDismiss != null,
           'You need to return a [Future] that completes with true or false in [onDismiss].');
-      if (!shouldDismiss) return;
+      if (!shouldDismiss && !force) return;
     }
     _openController.stop();
     _pulseController.stop();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,18 @@ authors:
 homepage: https://github.com/ayalma/feature_discovery
 
 environment:
-  sdk: '>=2.2.2 <3.0.0' # This should never be higher than the Flutter stable constraints.
+  # This should match the Flutter stable SDK constraint.
+  # See https://github.com/flutter/flutter/blob/stable/packages/flutter/pubspec.yaml.
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  provider: ^4.0.2
+
+  provider: ^4.0.4
 
 dev_dependencies:
-  pedantic: any
   flutter_test:
     sdk: flutter
+
+  pedantic: 1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,3 +26,7 @@ dev_dependencies:
     sdk: flutter
 
   pedantic: 1.9.0
+
+dependency_overrides:
+  # TODO(creativecreatorormaybenot): Remove when Pedantic is updated in flutter_test.
+  pedantic: 1.9.0

--- a/test/feature_discovery_test.dart
+++ b/test/feature_discovery_test.dart
@@ -20,13 +20,13 @@ void main() {
       'featureIdC',
       'featureIdD',
     ];
-    final List<String> texts = textsToMatch(steps);
+    final texts = textsToMatch(steps);
     testWidgets('Displaying two steps and dismissing before the third',
         (WidgetTester tester) async {
       await tester.pumpWidget(const TestWidget(featureIds: steps));
-      final Finder finder = find.byType(TestIcon);
+      final finder = find.byType(TestIcon);
       expect(finder, findsNWidgets(steps.length));
-      final BuildContext context = tester.firstState(finder).context;
+      final context = tester.firstState(finder).context;
       // Should be no overlays before calling discoverFeatures
       texts.forEach((t) => expect(find.text(t), findsNothing));
       FeatureDiscovery.discoverFeatures(context, steps);
@@ -61,9 +61,9 @@ void main() {
       await tester.pumpWidget(TestWidget(
           // Only one overlay will be placed in the tree
           featureIds: featureIds.sublist(1, 2)));
-      final Finder finder = find.byType(TestIcon);
+      final finder = find.byType(TestIcon);
       expect(finder, findsOneWidget);
-      final BuildContext context = tester.firstState(finder).context;
+      final context = tester.firstState(finder).context;
       FeatureDiscovery.discoverFeatures(context, featureIds);
       await tester.pumpAndSettle();
       // First overlay should NOT appear
@@ -80,7 +80,7 @@ void main() {
   });
 
   group('Duplicate feature ids', () {
-    for (final bool allowShowingDuplicate in <bool>[true, false]) {
+    for (final allowShowingDuplicate in <bool>[true, false]) {
       const featureIds = <String>[
         'featureIdA',
         'featureIdB',
@@ -102,9 +102,9 @@ void main() {
           allowShowingDuplicate: allowShowingDuplicate,
         ));
 
-        final Finder finder = find.byType(TestIcon);
+        final finder = find.byType(TestIcon);
         expect(finder, findsNWidgets(featureIds.length));
-        final BuildContext context = tester.firstState(finder).context;
+        final context = tester.firstState(finder).context;
         texts.forEach((t) => expect(find.text(t), findsNothing));
 
         FeatureDiscovery.discoverFeatures(context, steps);
@@ -131,9 +131,9 @@ void main() {
 
     testWidgets('Show other overlay after duplicate has been removed',
         (WidgetTester tester) async {
-      const String featureId = 'feature';
-      const IconData featureIcon = Icons.content_copy;
-      const String staticFeatureTitle = 'Static',
+      const featureId = 'feature';
+      const featureIcon = Icons.content_copy;
+      const staticFeatureTitle = 'Static',
           disposableFeatureTitle = 'Disposable';
 
       await tester.pumpWidget(const WidgetWithDisposableFeature(
@@ -143,14 +143,14 @@ void main() {
         disposableFeatureTitle: disposableFeatureTitle,
       ));
 
-      final Finder stateFinder = find.byType(WidgetWithDisposableFeature);
+      final stateFinder = find.byType(WidgetWithDisposableFeature);
       expect(stateFinder, findsOneWidget);
-      final WidgetWithDisposableFeatureState state =
-          tester.firstState(stateFinder);
+      final state =
+          tester.firstState(stateFinder) as WidgetWithDisposableFeatureState;
 
       // Need some widget to return a context that has the Bloc widget as an ancestor.
-      final Finder overlayFinder = find.byType(DescribedFeatureOverlay);
-      final BuildContext context = tester.firstState(overlayFinder).context;
+      final overlayFinder = find.byType(DescribedFeatureOverlay);
+      final context = tester.firstState(overlayFinder).context;
 
       // Feature titles should only be visible once feature discovery has been started.
       expect(find.text(staticFeatureTitle), findsNothing);
@@ -179,22 +179,22 @@ void main() {
   });
 
   group('OverflowMode', () {
-    const IconData icon = Icons.error;
-    const String featureId = 'feature';
+    const icon = Icons.error;
+    const featureId = 'feature';
 
     // Declares what OverflowMode's should allow the button to be tapped.
-    const Map<OverflowMode, bool> modes = <OverflowMode, bool>{
+    const modes = <OverflowMode, bool>{
       OverflowMode.ignore: false,
       OverflowMode.extendBackground: false,
       OverflowMode.wrapBackground: false,
       OverflowMode.clipContent: true,
     };
 
-    for (final MapEntry<OverflowMode, bool> modeEntry in modes.entries) {
+    for (final modeEntry in modes.entries) {
       testWidgets(modeEntry.key.toString(), (WidgetTester tester) async {
         BuildContext context;
 
-        bool triggered = false;
+        var triggered = false;
 
         // The surface size is set to ensure that the minimum overlay background size
         // does not cover the button, but the content does.

--- a/test/widgets.dart
+++ b/test/widgets.dart
@@ -72,7 +72,7 @@ class TestIcon extends StatefulWidget {
 class TestIconState extends State<TestIcon> {
   @override
   Widget build(BuildContext context) {
-    const Icon icon = Icon(Icons.more_horiz);
+    const icon = Icon(Icons.more_horiz);
     return DescribedFeatureOverlay(
       featureId: widget.featureId,
       // It is mandatory to disable the pulsing animation


### PR DESCRIPTION
This PR will fix https://github.com/ayalma/feature_discovery/issues/14.

The problem is simple: when detecting a tap outside an overlay, we directly called the bloc's `dismiss` function. The bloc then would send an event to all the overlays and delete its references to them, without checking if they'd be effectively dismissed.

With this PR, an overlay first tries to dismiss itself before calling the bloc.

I also changed `FeatureDiscovery.dismissAll` behavior: when calling it, all overlays will be forced-dismissed regardless of the returned value of `onDismiss`.